### PR TITLE
Retry connection to redis in case of RedisConnectionException

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,32 @@ The SSL provider to use.
 
 
 
+##### `redis.connection.retry`
+
+The number of attempt when connecting to redis
+
+*Importance:* Medium
+
+*Type:* Integer
+
+*Default Value:* 3
+
+
+
+##### `redis.connection.retryPause`
+
+The amount of milliseconds to wait between two redis connection attempt
+
+*Importance:* Medium
+
+*Type:* Integer
+
+*Default Value:* 2000
+
+*Validator:* Must be at least 100
+
+
+
 
 
 #### Examples

--- a/README.md
+++ b/README.md
@@ -246,9 +246,9 @@ The SSL provider to use.
 
 
 
-##### `redis.connection.retry`
+##### `redis.connection.attempts`
 
-The number of attempt when connecting to redis
+The number of attempts when connecting to redis
 
 *Importance:* Medium
 
@@ -258,9 +258,9 @@ The number of attempt when connecting to redis
 
 
 
-##### `redis.connection.retryPause`
+##### `redis.connection.retry.delay.ms`
 
-The amount of milliseconds to wait between two redis connection attempt
+The amount of milliseconds to wait between two redis connection attempts
 
 *Importance:* Medium
 

--- a/src/main/java/com/github/jcustenborder/kafka/connect/redis/RedisSinkConnectorConfig.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/redis/RedisSinkConnectorConfig.java
@@ -35,17 +35,17 @@ class RedisSinkConnectorConfig extends RedisConnectorConfig {
   public final static String INSERTION_TYPE_CONF = "redis.insertion.type";
   public final static String INSERTION_TYPE_DOC = "The type of insertion : SET, LPUSH, RPUSH";
 
-  public final static String CONNECTION_RETRY_CONF = "redis.connection.retry";
-  public final static String CONNECTION_RETRY_DOC = "The number of attempt when connecting to redis";
+  public final static String CONNECTION_ATTEMPTS_CONF = "redis.connection.attempts";
+  public final static String CONNECTION_ATTEMPTS_DOC = "The number of attempt when connecting to redis";
 
-  public final static String CONNECTION_RETRY_PAUSE_CONF = "redis.connection.retryPause";
-  public final static String CONNECTION_RETRY_PAUSE_DOC = "The amount of milliseconds to wait between two redis connection attempt";
+  public final static String CONNECTION_RETRY_DELAY_MS_CONF = "redis.connection.retry.delay.ms";
+  public final static String CONNECTION_RETRY_DELAY_MS_DOC = "The amount of milliseconds to wait between two redis connection attempt";
 
   public final long operationTimeoutMs;
   public final Charset charset;
   public final SinkOperation.Type type;
-  public final int retryPause;
-  public final int maxRetries;
+  public final int retryDelay;
+  public final int maxAttempts;
 
   public RedisSinkConnectorConfig(Map<?, ?> originals) {
     super(config(), originals);
@@ -54,8 +54,8 @@ class RedisSinkConnectorConfig extends RedisConnectorConfig {
     this.charset = Charset.forName(charset);
     String type = getString(INSERTION_TYPE_CONF);
     this.type = SinkOperation.Type.valueOf(type);
-    this.maxRetries = getInt(CONNECTION_RETRY_CONF);
-    this.retryPause = getInt(CONNECTION_RETRY_PAUSE_CONF);
+    this.maxAttempts = getInt(CONNECTION_ATTEMPTS_CONF);
+    this.retryDelay = getInt(CONNECTION_RETRY_DELAY_MS_CONF);
   }
 
   public static ConfigDef config() {
@@ -84,14 +84,14 @@ class RedisSinkConnectorConfig extends RedisConnectorConfig {
                 .importance(ConfigDef.Importance.MEDIUM)
                 .build()
         ).define(
-            ConfigKeyBuilder.of(CONNECTION_RETRY_CONF, ConfigDef.Type.INT)
-                    .documentation(CONNECTION_RETRY_DOC)
+            ConfigKeyBuilder.of(CONNECTION_ATTEMPTS_CONF, ConfigDef.Type.INT)
+                    .documentation(CONNECTION_ATTEMPTS_DOC)
                     .defaultValue(3)
                     .importance(ConfigDef.Importance.MEDIUM)
                     .build()
         ).define(
-            ConfigKeyBuilder.of(CONNECTION_RETRY_PAUSE_CONF, ConfigDef.Type.INT)
-                    .documentation(CONNECTION_RETRY_PAUSE_DOC)
+            ConfigKeyBuilder.of(CONNECTION_RETRY_DELAY_MS_CONF, ConfigDef.Type.INT)
+                    .documentation(CONNECTION_RETRY_DELAY_MS_DOC)
                     .defaultValue(2000)
                     .validator(ConfigDef.Range.atLeast(100))
                     .importance(ConfigDef.Importance.MEDIUM)

--- a/src/main/java/com/github/jcustenborder/kafka/connect/redis/RedisSinkTask.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/redis/RedisSinkTask.java
@@ -108,18 +108,17 @@ public class RedisSinkTask extends SinkTask {
   }
 
   private void connectToRedis() {
-    int count = 0;
+    int attempts = 1;
     while (true) {
       try {
         this.session = RedisSessionImpl.create(this.config);
         break;
       } catch (RedisConnectionException e) {
-        ++count;
-        log.info("Fail to connect to Redis. Will retry in {}ms. Tentative {} on {} ", config.retryPause, count, config.maxRetries);
+        log.warn("Fail to connect to Redis. Will retry in {}ms. Tentative {} on {} ", config.retryDelay, attempts, config.maxAttempts);
+        if (attempts >= config.maxAttempts) throw e;
         try {
-          Thread.sleep(config.retryPause);
+          Thread.sleep(config.retryDelay);
         } catch (InterruptedException ignored) { }
-        if (count > config.maxRetries) throw e;
       }
     }
   }


### PR DESCRIPTION
Add a retry capability to the initial redis connection.
I did this because I'm in a k8s environment. To be resilient, my redis pod is in charge of registering the kafka connector in a postStart or in an InitContainer. With this approach, the redis server might no be available yet when the connector starts
I hesitate between doing this in RedisThinkTask or RedisSessionImpl. I choosed RedisThinkTask because for me, the retry mechanism is not really part of the redis connection process, but is more like a fallback wrapper around it.

