### PR TITLE
support for json format in kafka keys and values

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The Redis Sink Connector is used to write data from Kafka to a Redis cache.
 
 ### Important
 
-This connector expects records from Kafka to have a key and value that are stored as bytes or a string. If your data is already in Kafka in the format that you want in Redis consider using the ByteArrayConverter or the StringConverter for this connector. Keep in this does not need to be configured in the worker properties and can be configured at the connector level. If your data is not sitting in Kafka in the format you wish to persist in Redis consider using a Single Message Transformation to convert the data to a byte or string representation before it is written to Redis.
+This connector expects records from Kafka to have a key and value that are stored as a map, bytes or a string. If your data is already in Kafka in the format that you want in Redis consider using the JsonConverter, ByteArrayConverter or the StringConverter for this connector. Keep in mind this does not need to be configured in the worker properties and can be configured at the connector level. If your data is not sitting in Kafka in the format you wish to persist in Redis consider using a Single Message Transformation to convert the data to a map, byte or string representation before it is written to Redis.
 ### Note
 
 This connector supports deletes. If the record stored in Kafka has a null value, this connector will send a delete with the corresponding key to Redis.

--- a/src/main/java/com/github/jcustenborder/kafka/connect/redis/RedisSinkTask.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/redis/RedisSinkTask.java
@@ -21,6 +21,7 @@ import com.github.jcustenborder.kafka.connect.utils.data.SinkOffsetState;
 import com.github.jcustenborder.kafka.connect.utils.data.TopicPartitionCounter;
 import com.github.jcustenborder.kafka.connect.utils.jackson.ObjectMapperFactory;
 import com.google.common.base.Charsets;
+import com.google.common.base.Joiner;
 import io.lettuce.core.KeyValue;
 import io.lettuce.core.RedisFuture;
 import org.apache.kafka.common.TopicPartition;
@@ -113,16 +114,18 @@ public class RedisSinkTask extends SinkTask {
       result = s.getBytes(this.config.charset);
     } else if (input instanceof byte[]) {
       result = (byte[]) input;
+    } else if (input instanceof Map) {
+      result = Joiner.on(",").withKeyValueSeparator("=").join((Map) input).getBytes(this.config.charset);
     } else if (null == input) {
       result = null;
     } else {
       throw new DataException(
           String.format(
-              "The %s for the record must be String or Bytes. Consider using the ByteArrayConverter " +
-                  "or StringConverter if the data is stored in Kafka in the format needed in Redis. " +
-                  "Another option is to use a single message transformation to transform the data before " +
-                  "it is written to Redis.",
-              source
+              "The %s for the record must be Map, String or Bytes, but actually is %s. Consider using the " +
+                  "JsonConverter, ByteArrayConverter or StringConverter if the data is stored in Kafka in the format " +
+                  "needed in Redis. Another option is to use a single message transformation to transform the data " +
+                  "before it is written to Redis.",
+              source, input.getClass()
           )
       );
     }


### PR DESCRIPTION
We would like to make use of SMT on our data in Kafka, which seems to be impossible on Strings or byte[]. So instead of using the StringConverter or ByteArrayConverter, we need to make use of the JsonConverter. For now this runs into an error, since the input is neither String nor byte[]. 
This is why I suppose this change to add the functionality to support Map structured data as input. I am looking forward for your feedback on my proposal.