### PR TITLE
Fixed memory leak issue with RedisClient

### DIFF
--- a/src/main/java/com/github/jcustenborder/kafka/connect/redis/RedisSessionFactoryImpl.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/redis/RedisSessionFactoryImpl.java
@@ -178,6 +178,7 @@ class RedisSessionFactoryImpl implements RedisSessionFactory {
     @Override
     public void close() throws Exception {
       this.connection.close();
+      this.client.shutdown();
     }
   }
 }


### PR DESCRIPTION
Was getting log messages such as 
```
[2021-06-28 19:39:07,323] WARN io.lettuce.core.resource.DefaultClientResources was not shut down properly, shutdown() was not called before it's garbage-collected. Call shutdown() or shutdown(long,long,TimeUnit)  (io.lettuce.core.resource.DefaultClientResources)
```
and 
```
[2021-06-29 04:01:40,280] ERROR LEAK: HashedWheelTimer.release() was not called before it's garbage-collected. See https://netty.io/wiki/reference-counted-objects.html for more information.
```
which indicated the client wasn't being properly shut down. This pull request fixes this.