### PR TITLE
Issue #6- Add Support for Redis Pub Sub

### DIFF
--- a/src/main/java/com/github/jcustenborder/kafka/connect/redis/RedisRecord.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/redis/RedisRecord.java
@@ -1,7 +1,20 @@
+/**
+ * Copyright © 2017 Jeremy Custenborder (jcustenborder@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.jcustenborder.kafka.connect.redis;
-//
-//import org.apache.kafka.connect.errors.DataException;
-//import org.apache.kafka.connect.sink.SinkRecord;
+
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.github.jcustenborder.kafka.connect.utils.data.SinkOffsetState;
@@ -12,93 +25,104 @@ import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.charset.StandardCharsets;
+
 public class RedisRecord {
-    private static final Logger log = LoggerFactory.getLogger(RedisRecord.class);
+  private static final Logger log = LoggerFactory.getLogger(RedisRecord.class);
+  private final byte[] key;
+  private final byte[] value;
+  private final SinkOperation.Type type;
 
-    private final byte[] key;
-    private final byte[] value;
+  RedisRecord(byte[] key, byte[] value, SinkOperation.Type type) {
+    this.key = key;
+    this.value = value;
+    this.type = type;
+  }
 
-    private RedisRecord(byte[] key, byte[] value) {
-        this.key = key;
-        this.value = value;
+  public byte[] key() {
+    return this.key;
+  }
+
+  public byte[] value() {
+    return this.value;
+  }
+
+  public SinkOperation.Type type() {
+    return this.type;
+  }
+
+  public static RedisRecord fromBatchableSinkRecord(SinkRecord record, RedisSinkConnectorConfig config) throws DataException {
+    return new RedisRecord(
+      keyFromRecord(record, config),
+      toBytes("value", record.value(), config),
+      record.value() == null ? SinkOperation.Type.DELETE : SinkOperation.Type.SET
+    );
+  }
+
+  public static RedisRecord fromSinkRecord(SinkRecord record, RedisSinkConnectorConfig config) {
+    return new RedisRecord(
+      config.redisChannel.getBytes(StandardCharsets.UTF_8),
+      toBytes("value", record.value(), config),
+      SinkOperation.Type.PUBLISH
+    );
+  }
+
+  public static RedisRecord fromSinkOffsetState(SinkOffsetState e) {
+    final byte[] key = String.format("__kafka.offset.%s.%s", e.topic(), e.partition()).getBytes(Charsets.UTF_8);
+    final byte[] value;
+    try {
+      value = ObjectMapperFactory.INSTANCE.writeValueAsBytes(e);
+    } catch (JsonProcessingException e1) {
+      throw new DataException(e1);
     }
+    log.trace("RedisRecord::fromSinkOffsetState: Setting offset: {}", e);
+    return new RedisRecord(key, value, SinkOperation.Type.SET);
+  }
 
-    public byte[] key() {
-        return this.key;
+  private static byte[] keyFromRecord(SinkRecord record, RedisSinkConnectorConfig config) {
+    log.trace("RedisRecord::keyFromRecord - Processing record " + formatLocation(record));
+    if (record.key() == null) {
+      throw new DataException(
+        "The key for the record cannot be null. " + formatLocation(record)
+      );
     }
-
-    public byte[] value() {
-        return this.value;
+    final byte[] key = toBytes("key", record.key(), config);
+    if (null == key || key.length == 0) {
+      throw new DataException(
+        "The key cannot be an empty byte array. " + formatLocation(record)
+      );
     }
+    return key;
+  }
 
-
-    public static RedisRecord fromDeleteRecord(SinkRecord deleteRecord, RedisSinkConnectorConfig config) throws DataException {
-        return new RedisRecord(keyFromRecord(deleteRecord, config), null);
+  private static byte[] toBytes(String source, Object input, RedisSinkConnectorConfig config) {
+    final byte[] result;
+    if (input instanceof String) {
+      String s = (String) input;
+      result = s.getBytes(config.charset);
+    } else if (input instanceof byte[]) {
+      result = (byte[]) input;
+    } else if (null == input) {
+      result = null;
+    } else {
+      throw new DataException(
+        String.format(
+          "The %s for the record must be String or Bytes. Consider using the ByteArrayConverter " +
+                  "or StringConverter if the data is stored in Kafka in the format needed in Redis. " +
+                  "Another option is to use a single message transformation to transform the data before " +
+                  "it is written to Redis.",
+          source
+        ));
     }
+    return result;
+  }
 
-    public static RedisRecord fromSetRecord(SinkRecord setRecord, RedisSinkConnectorConfig config) {
-        return new RedisRecord(keyFromRecord(setRecord, config), toBytes("value", setRecord.value(), config));
-    }
-
-    public static RedisRecord fromSinkOffsetState(SinkOffsetState e) {
-        final byte[] key = String.format("__kafka.offset.%s.%s", e.topic(), e.partition()).getBytes(Charsets.UTF_8);
-        final byte[] value;
-        try {
-            value = ObjectMapperFactory.INSTANCE.writeValueAsBytes(e);
-        } catch (JsonProcessingException e1) {
-            throw new DataException(e1);
-        }
-        log.trace("RedisRecord::fromSinkOffsetState: Setting offset: {}", e);
-        return new RedisRecord(key, value);
-    }
-
-    private static byte[] keyFromRecord(SinkRecord record, RedisSinkConnectorConfig config) {
-        log.trace("RedisRecord::keyFromRecord - Processing record " + formatLocation(record));
-        if (record.key() == null) {
-            throw new DataException(
-                    "The key for the record cannot be null. " + formatLocation(record)
-            );
-        }
-        final byte[] key = toBytes("key", record.key(), config);
-        if (null == key || key.length == 0) {
-            throw new DataException(
-                    "The key cannot be an empty byte array. " + formatLocation(record)
-            );
-        }
-        return key;
-    }
-
-    private static byte[] toBytes(String source, Object input, RedisSinkConnectorConfig config) {
-        final byte[] result;
-
-        if (input instanceof String) {
-            String s = (String) input;
-            result = s.getBytes(config.charset);
-        } else if (input instanceof byte[]) {
-            result = (byte[]) input;
-        } else if (null == input) {
-            result = null;
-        } else {
-            throw new DataException(
-                    String.format(
-                            "The %s for the record must be String or Bytes. Consider using the ByteArrayConverter " +
-                                    "or StringConverter if the data is stored in Kafka in the format needed in Redis. " +
-                                    "Another option is to use a single message transformation to transform the data before " +
-                                    "it is written to Redis.",
-                            source
-                    )
-            );
-        }
-
-        return result;
-    }
-
-    static String formatLocation(SinkRecord record) {
-        return String.format(
-                "topic = %s partition = %s offset = %s",
-                record.topic(),
-                record.kafkaPartition(),
-                record.kafkaOffset()
-        );
-    }
+  static String formatLocation(SinkRecord record) {
+    return String.format(
+      "topic = %s partition = %s offset = %s",
+      record.topic(),
+      record.kafkaPartition(),
+      record.kafkaOffset()
+    );
+  }
 }

--- a/src/main/java/com/github/jcustenborder/kafka/connect/redis/RedisRecord.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/redis/RedisRecord.java
@@ -1,0 +1,104 @@
+package com.github.jcustenborder.kafka.connect.redis;
+//
+//import org.apache.kafka.connect.errors.DataException;
+//import org.apache.kafka.connect.sink.SinkRecord;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.github.jcustenborder.kafka.connect.utils.data.SinkOffsetState;
+import com.github.jcustenborder.kafka.connect.utils.jackson.ObjectMapperFactory;
+import com.google.common.base.Charsets;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RedisRecord {
+    private static final Logger log = LoggerFactory.getLogger(RedisRecord.class);
+
+    private final byte[] key;
+    private final byte[] value;
+
+    private RedisRecord(byte[] key, byte[] value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public byte[] key() {
+        return this.key;
+    }
+
+    public byte[] value() {
+        return this.value;
+    }
+
+
+    public static RedisRecord fromDeleteRecord(SinkRecord deleteRecord, RedisSinkConnectorConfig config) throws DataException {
+        return new RedisRecord(keyFromRecord(deleteRecord, config), null);
+    }
+
+    public static RedisRecord fromSetRecord(SinkRecord setRecord, RedisSinkConnectorConfig config) {
+        return new RedisRecord(keyFromRecord(setRecord, config), toBytes("value", setRecord.value(), config));
+    }
+
+    public static RedisRecord fromSinkOffsetState(SinkOffsetState e) {
+        final byte[] key = String.format("__kafka.offset.%s.%s", e.topic(), e.partition()).getBytes(Charsets.UTF_8);
+        final byte[] value;
+        try {
+            value = ObjectMapperFactory.INSTANCE.writeValueAsBytes(e);
+        } catch (JsonProcessingException e1) {
+            throw new DataException(e1);
+        }
+        log.trace("RedisRecord::fromSinkOffsetState: Setting offset: {}", e);
+        return new RedisRecord(key, value);
+    }
+
+    private static byte[] keyFromRecord(SinkRecord record, RedisSinkConnectorConfig config) {
+        log.trace("RedisRecord::keyFromRecord - Processing record " + formatLocation(record));
+        if (record.key() == null) {
+            throw new DataException(
+                    "The key for the record cannot be null. " + formatLocation(record)
+            );
+        }
+        final byte[] key = toBytes("key", record.key(), config);
+        if (null == key || key.length == 0) {
+            throw new DataException(
+                    "The key cannot be an empty byte array. " + formatLocation(record)
+            );
+        }
+        return key;
+    }
+
+    private static byte[] toBytes(String source, Object input, RedisSinkConnectorConfig config) {
+        final byte[] result;
+
+        if (input instanceof String) {
+            String s = (String) input;
+            result = s.getBytes(config.charset);
+        } else if (input instanceof byte[]) {
+            result = (byte[]) input;
+        } else if (null == input) {
+            result = null;
+        } else {
+            throw new DataException(
+                    String.format(
+                            "The %s for the record must be String or Bytes. Consider using the ByteArrayConverter " +
+                                    "or StringConverter if the data is stored in Kafka in the format needed in Redis. " +
+                                    "Another option is to use a single message transformation to transform the data before " +
+                                    "it is written to Redis.",
+                            source
+                    )
+            );
+        }
+
+        return result;
+    }
+
+    static String formatLocation(SinkRecord record) {
+        return String.format(
+                "topic = %s partition = %s offset = %s",
+                record.topic(),
+                record.kafkaPartition(),
+                record.kafkaOffset()
+        );
+    }
+}

--- a/src/main/java/com/github/jcustenborder/kafka/connect/redis/RedisSinkTask.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/redis/RedisSinkTask.java
@@ -32,17 +32,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class RedisSinkTask extends SinkTask {
   private static final Logger log = LoggerFactory.getLogger(RedisSinkTask.class);
@@ -105,131 +100,57 @@ public class RedisSinkTask extends SinkTask {
     }
   }
 
-  private byte[] toBytes(String source, Object input) {
-    final byte[] result;
+    @Override
+    public void put(Collection <SinkRecord> records) {
+      log.debug("put() - Processing {} record(s)", records.size());
+      SinkOperation deleteOp = SinkOperation.create(SinkOperation.Type.DELETE, this.config, records.size());
+      Stream<RedisRecord> deletes = records
+              .stream()
+              .filter(r -> r.value() == null)
+              .map(r -> RedisRecord.fromDeleteRecord(r, this.config));
+      deletes.forEach(d -> deleteOp.add(d.key(), d.value()));
 
-    if (input instanceof String) {
-      String s = (String) input;
-      result = s.getBytes(this.config.charset);
-    } else if (input instanceof byte[]) {
-      result = (byte[]) input;
-    } else if (null == input) {
-      result = null;
-    } else {
-      throw new DataException(
-          String.format(
-              "The %s for the record must be String or Bytes. Consider using the ByteArrayConverter " +
-                  "or StringConverter if the data is stored in Kafka in the format needed in Redis. " +
-                  "Another option is to use a single message transformation to transform the data before " +
-                  "it is written to Redis.",
-              source
-          )
-      );
-    }
+      SinkOperation setOp = SinkOperation.create(SinkOperation.Type.SET, this.config, records.size());
+      Stream<RedisRecord> sets = Stream.concat(
+              records
+                      .stream()
+                      .filter(r -> r.value() != null)
+                      .map(r -> RedisRecord.fromSetRecord(r, this.config)),
+              records
+                      .stream()
+                      .map(r -> SinkOffsetState.of(r.topic(), r.kafkaPartition(), r.kafkaOffset()))
+                      .map(RedisRecord::fromSinkOffsetState)
+              );
+      sets.forEach(s -> setOp.add(s.key(), s.value()));
 
-    return result;
-  }
-
-  static String formatLocation(SinkRecord record) {
-    return String.format(
-        "topic = %s partition = %s offset = %s",
-        record.topic(),
-        record.kafkaPartition(),
-        record.kafkaOffset()
-    );
-  }
-
-  @Override
-  public void put(Collection<SinkRecord> records) {
-    log.debug("put() - Processing {} record(s)", records.size());
-    List<SinkOperation> operations = new ArrayList<>(records.size());
-
-    SinkOperation operation = SinkOperation.NONE;
-
-    TopicPartitionCounter counter = new TopicPartitionCounter();
-
-    for (SinkRecord record : records) {
-      log.trace("put() - Processing record " + formatLocation(record));
-      if (null == record.key()) {
-        throw new DataException(
-            "The key for the record cannot be null. " + formatLocation(record)
-        );
-      }
-      final byte[] key = toBytes("key", record.key());
-      if (null == key || key.length == 0) {
-        throw new DataException(
-            "The key cannot be an empty byte array. " + formatLocation(record)
-        );
-      }
-
-      final byte[] value = toBytes("value", record.value());
-
-      SinkOperation.Type currentOperationType;
-
-      if (null == value) {
-        currentOperationType = SinkOperation.Type.DELETE;
-      } else {
-        currentOperationType = SinkOperation.Type.SET;
-      }
-
-      if (currentOperationType != operation.type) {
-        log.debug(
-            "put() - Creating new operation. current={} last={}",
-            currentOperationType,
-            operation.type
-        );
-        operation = SinkOperation.create(currentOperationType, this.config, records.size());
-        operations.add(operation);
-      }
-      operation.add(key, value);
-      counter.increment(record.topic(), record.kafkaPartition(), record.kafkaOffset());
-    }
-
-    log.debug(
-        "put() - Found {} operation(s) in {} record{s}. Executing operations...",
-        operations.size(),
-        records.size()
-    );
-
-    final List<SinkOffsetState> offsetData = counter.offsetStates();
-    if (!offsetData.isEmpty()) {
-      operation = SinkOperation.create(SinkOperation.Type.SET, this.config, offsetData.size());
-      operations.add(operation);
-      for (SinkOffsetState e : offsetData) {
-        final byte[] key = String.format("__kafka.offset.%s.%s", e.topic(), e.partition()).getBytes(Charsets.UTF_8);
-        final byte[] value;
+      Arrays.asList(deleteOp, setOp).forEach(op -> {
         try {
-          value = ObjectMapperFactory.INSTANCE.writeValueAsBytes(e);
-        } catch (JsonProcessingException e1) {
-          throw new DataException(e1);
+          if (op.size() > 0) {
+            log.debug(
+                    "put() - Found  operation of type {} in {} record{s}. Executing operation...",
+                    op.type,
+                    op.size()
+            );
+            op.execute(this.session.asyncCommands());
+          }
+        } catch (InterruptedException e) {
+          e.printStackTrace();
         }
-        operation.add(key, value);
-        log.trace("put() - Setting offset: {}", e);
-      }
+      });
     }
 
-    for (SinkOperation op : operations) {
-      log.debug("put() - Executing {} operation with {} values", op.type, op.size());
+    private static String redisOffsetKey (TopicPartition topicPartition){
+      return String.format("__kafka.offset.%s.%s", topicPartition.topic(), topicPartition.partition());
+    }
+
+    @Override
+    public void stop () {
       try {
-        op.execute(this.session.asyncCommands());
-      } catch (InterruptedException e) {
-        throw new RetriableException(e);
+        if (null != this.session) {
+          this.session.close();
+        }
+      } catch (Exception e) {
+        log.warn("Exception thrown", e);
       }
     }
   }
-
-  private static String redisOffsetKey(TopicPartition topicPartition) {
-    return String.format("__kafka.offset.%s.%s", topicPartition.topic(), topicPartition.partition());
-  }
-
-  @Override
-  public void stop() {
-    try {
-      if (null != this.session) {
-        this.session.close();
-      }
-    } catch (Exception e) {
-      log.warn("Exception thrown", e);
-    }
-  }
-}

--- a/src/main/java/com/github/jcustenborder/kafka/connect/redis/SinkOperation.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/redis/SinkOperation.java
@@ -42,6 +42,7 @@ abstract class SinkOperation {
   public enum Type {
     SET,
     DELETE,
+    PUBLISH,
     NONE
   }
 

--- a/src/test/java/com/github/jcustenborder/kafka/connect/redis/RedisSinkTaskTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/redis/RedisSinkTaskTest.java
@@ -145,9 +145,8 @@ public class RedisSinkTaskTest {
     task.put(records);
 
     InOrder inOrder = Mockito.inOrder(asyncCommands);
-    inOrder.verify(asyncCommands).mset(anyMap());
     inOrder.verify(asyncCommands).del(any(byte[].class));
-    inOrder.verify(asyncCommands, times(2)).mset(anyMap());
+    inOrder.verify(asyncCommands).mset(anyMap());
   }
 
 }


### PR DESCRIPTION
https://github.com/jcustenborder/kafka-connect-redis/issues/6 

Add support for Redis Pub Sub:

- add config properties:
    `redis.action` can be `publish` or `set` (defaults to current behavior, `set`)
    `redis.channel` (optional) to specify which redis channel to publish to
- update the `put` method to support a "streaming" action rather than a "batching" only.
- added a RedisRecord class which encapsulates logic for determining the redis key and value, cleaning up the RedisTask a little bit