### PR TITLE
Fix the CVE-2020-8908, by bumping guava

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.github.jcustenborder.kafka.connect</groupId>
         <artifactId>kafka-connect-parent</artifactId>
-        <version>2.2.1-cp1</version>
+        <version>2.8.0-1</version>
     </parent>
     <artifactId>kafka-connect-redis</artifactId>
     <version>0.0.2-SNAPSHOT</version>


### PR DESCRIPTION
Verified with `mvn dependency:tree`
```
[INFO] +- com.github.jcustenborder.kafka.connect:connect-utils:jar:0.7.171:compile
[INFO] |  +- org.immutables:value:jar:2.8.2:compile
[INFO] |  +- com.google.guava:guava:jar:30.1.1-jre:compile
```