### PR TITLE
Upgrade lettuce to the latest version for redis 7 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>io.lettuce</groupId>
             <artifactId>lettuce-core</artifactId>
-            <version>5.2.1.RELEASE</version>
+            <version>6.2.5.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>com.github.jcustenborder.kafka.connect</groupId>


### PR DESCRIPTION
Lettuce 5 does not support Redis 7. I am naively expecting that a bump to the most recent lettuce version would fix the issue. This of course would require releasing a new connector version.

